### PR TITLE
Initialize variable based on ParseratorType

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    name: Test against different Python versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.7.x, 3.8.x]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+        architecture: x64
+    - name: Install packages and run tests
+      run: |
+        pip install --upgrade pip
+        pip install -e .[tests]
+        parserator train training/labeled.xml ilcs_parser
+        pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,5 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[tests]
-        pip install -i https://test.pypi.org/simple/ ilcs-parser
+        pip install -U -i https://test.pypi.org/simple/ ilcs-parser
         pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,5 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[tests]
-        python -c "import ilcs_parser; print(ilcs_parser.__file__)"
-        parserator train training/labeled.xml ilcs_parser
+        pip install -i https://test.pypi.org/simple/ ilcs-parser
         pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,6 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[tests]
+        python -c "import ilcs_parser; print(ilcs_parser.__file__)"
         parserator train training/labeled.xml ilcs_parser
         pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,6 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[tests]
-        pip install -U -i https://test.pypi.org/simple/ ilcs-parser
+        pip uninstall -y ilcs-parser
+        pip install -i https://test.pypi.org/simple/ ilcs-parser
         pytest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,41 @@
 # dedupe-variable-ilcs
-Dedupe variable for Illinois Compiled Statute (ILCS) codes
+
+Dedupe variable for Illinois Compiled Statute (ILCS) codes.
 
 Part of the [Dedupe.io](https://dedupe.io/) cloud service and open source toolset for de-duplicating and finding fuzzy matches in your data.
+
+## Installation
+
+Install with `pip`:
+
+```
+pip install git+https://github.com/dedupeio/dedupe-variable-ilcs.git
+```
+
+## Development
+
+Local development requires an installation of Python.
+
+Install development requirements:
+
+```
+pip install -e .[tests]
+```
+
+Train the `ilcs_parser` model:
+
+```
+parserator train training/labeled.xml ilcs_parser
+```
+
+The variable should now be ready to use.
+
+### Running tests
+
+Run the tests:
+
+```
+pytest
+```
+
+All tests should pass.

--- a/dedupe/__init__.py
+++ b/dedupe/__init__.py
@@ -1,0 +1,4 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+from ._init import *

--- a/dedupe/variables/__init__.py
+++ b/dedupe/variables/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/dedupe/variables/ilcs.py
+++ b/dedupe/variables/ilcs.py
@@ -24,32 +24,15 @@ class ILCSType(ParseratorType):
         self.components = (('Citation', self.compareFields, CITATION),)
         block_parts = ('Citation',)
         super().__init__(definition, ilcs_parser.tag, block_parts)
+'''
+        # Add exact match to the distance vector
+        self.expanded_size += 1
 
-    def compareFields(self, parts, field_1, field_2):
+    def fields(self, field):
         """
-        Override the base comparison function to provide more semantically
-        meaningful comparisons of field_1 and field_2, depending on the type
-        of the field.
+        Override the parent method to append an exact match field.
         """
-        joinParts = functools.partial(consolidate, components=parts)
-        for part, (part_1, part_2) in zip(parts, zip(*map(joinParts, [field_1, field_2]))):
-            if part == ('Attempted',):
-                # We expect Attempted indicators like "(att)" to be strings
-                yield self.compareString(part_1, part_2)
-            else:
-                if part_1.isdigit() and part_2.isdigit():
-                    # If the fields are both all numeric, compare as numbers.
-                    # Use root difference so that each additional unit of
-                    # difference is less significant as the delta gets large
-                    yield math.sqrt(abs(int(part_1) - int(part_2)))
-                else:
-                    def is_single_alpha(x): return len(x) == 1 and set(x.lower()) < set(string.ascii_lowercase)
-                    if is_single_alpha(part_1) and is_single_alpha(part_2):
-                        # Both fields are single alphabetic characters, like
-                        # 'a', so we can compare the alphabetic distance.
-                        # Use root difference to scale the delta as the distance
-                        # across the alphabet grows
-                        def get_alpha_idx(x): return string.ascii_lowercase.index(x.lower())
-                        yield math.sqrt(abs(get_alpha_idx(part_1) - get_alpha_idx(part_2)))
-                    else:
-                        yield self.compareString(part_1, part_2)
+        fields = super().fields(field)
+        fields += [('exact match', 'Exact')]
+        return fields
+'''

--- a/dedupe/variables/ilcs.py
+++ b/dedupe/variables/ilcs.py
@@ -2,6 +2,7 @@ import string
 import math
 import functools
 
+import numpy
 import ilcs_parser
 from parseratorvariable import ParseratorType, consolidate
 
@@ -34,3 +35,20 @@ class ILCSType(ParseratorType):
         fields = super().fields(field)
         fields += [('exact match', 'Exact')]
         return fields
+
+    def comparator(self, field_1, field_2):
+        """
+        Override the parent method to append an exact match field.
+        """
+        # Temporarily subtract the exact match indicator from expanded_size,
+        # since the parent method assumes that the last element of the distance
+        # vector is the full-string comparison.
+        self.expanded_size -= 1
+        distances = super().comparator(field_1, field_2)
+        self.expanded_size += 1
+
+        # Set the exact match indicator variable.
+        exact_match = 1 if field_1 == field_2 else 0
+        distances = numpy.append(distances, exact_match)
+
+        return distances

--- a/dedupe/variables/ilcs.py
+++ b/dedupe/variables/ilcs.py
@@ -3,7 +3,6 @@ import math
 import functools
 
 import ilcs_parser
-import numpy
 from parseratorvariable import ParseratorType, consolidate
 
 CITATION = (

--- a/dedupe/variables/ilcs.py
+++ b/dedupe/variables/ilcs.py
@@ -24,7 +24,6 @@ class ILCSType(ParseratorType):
         self.components = (('Citation', self.compareFields, CITATION),)
         block_parts = ('Citation',)
         super().__init__(definition, ilcs_parser.tag, block_parts)
-'''
         # Add exact match to the distance vector
         self.expanded_size += 1
 
@@ -35,4 +34,3 @@ class ILCSType(ParseratorType):
         fields = super().fields(field)
         fields += [('exact match', 'Exact')]
         return fields
-'''

--- a/dedupe/variables/ilcs.py
+++ b/dedupe/variables/ilcs.py
@@ -1,12 +1,17 @@
+import string
+import math
+import functools
+
 import ilcs_parser
-from parseratorvariable import ParseratorType
+import numpy
+from parseratorvariable import ParseratorType, consolidate
 
 CITATION = (
     ('chapter', ('Chapter',)),
-    ('act prefix', ('ActPrefix')),
-    ('section', ('Section')),
-    ('subsection', ('SubSection')),
-    ('attempted', ('Attempted'))
+    ('act prefix', ('ActPrefix',)),
+    ('section', ('Section',)),
+    ('subsection', ('SubSection',)),
+    ('attempted', ('Attempted',))
 )
 
 
@@ -20,3 +25,32 @@ class ILCSType(ParseratorType):
         self.components = (('Citation', self.compareFields, CITATION),)
         block_parts = ('Citation',)
         super().__init__(definition, ilcs_parser.tag, block_parts)
+
+    def compareFields(self, parts, field_1, field_2):
+        """
+        Override the base comparison function to provide more semantically
+        meaningful comparisons of field_1 and field_2, depending on the type
+        of the field.
+        """
+        joinParts = functools.partial(consolidate, components=parts)
+        for part, (part_1, part_2) in zip(parts, zip(*map(joinParts, [field_1, field_2]))):
+            if part == ('Attempted',):
+                # We expect Attempted indicators like "(att)" to be strings
+                yield self.compareString(part_1, part_2)
+            else:
+                if part_1.isdigit() and part_2.isdigit():
+                    # If the fields are both all numeric, compare as numbers.
+                    # Use root difference so that each additional unit of
+                    # difference is less significant as the delta gets large
+                    yield math.sqrt(abs(int(part_1) - int(part_2)))
+                else:
+                    def is_single_alpha(x): return len(x) == 1 and set(x.lower()) < set(string.ascii_lowercase)
+                    if is_single_alpha(part_1) and is_single_alpha(part_2):
+                        # Both fields are single alphabetic characters, like
+                        # 'a', so we can compare the alphabetic distance.
+                        # Use root difference to scale the delta as the distance
+                        # across the alphabet grows
+                        def get_alpha_idx(x): return string.ascii_lowercase.index(x.lower())
+                        yield math.sqrt(abs(get_alpha_idx(part_1) - get_alpha_idx(part_2)))
+                    else:
+                        yield self.compareString(part_1, part_2)

--- a/dedupe/variables/ilcs.py
+++ b/dedupe/variables/ilcs.py
@@ -1,0 +1,22 @@
+import ilcs_parser
+from parseratorvariable import ParseratorType
+
+CITATION = (
+    ('chapter', ('Chapter',)),
+    ('act prefix', ('ActPrefix')),
+    ('section', ('Section')),
+    ('subsection', ('SubSection')),
+    ('attempted', ('Attempted'))
+)
+
+
+class ILCSType(ParseratorType):
+    type = 'ILCS'
+
+    def tagger(self, field):
+        return self.tag(field)
+
+    def __init__(self, definition):
+        self.components = (('Citation', self.compareFields, CITATION),)
+        block_parts = ('Citation',)
+        super().__init__(definition, ilcs_parser.tag, block_parts)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+try:
+    from setuptools import setup
+except ImportError:
+    raise ImportError(
+        "setuptools module required, please go to "
+        "https://pypi.python.org/pypi/setuptools and follow the instructions "
+        "for installing setuptools"
+    )
+
+setup(
+    version='0.0.0',
+    url='https://github.com/dedupeio/dedupe-variable-ilcs',
+    description='Dedupe variable for Illinois Compiled Statute (ILCS) codes',
+    name='dedupe-variable-ilcs',
+    packages=['dedupe.variables'],
+    license='The MIT License: http://www.opensource.org/licenses/mit-license.php',
+    install_requires=[
+        'ilcs-parser @ https://github.com/datamade/ilcs-parser/archive/jfc/init-parser.zip#egg=ilcs-parser-0.0.0',
+        'parseratorvariable'
+    ],
+    extras_require={'tests': ['pytest', 'parserator']},
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX',
+        'Programming Language :: Python :: 3',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Information Analysis']
+)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=['dedupe.variables'],
     license='The MIT License: http://www.opensource.org/licenses/mit-license.php',
     install_requires=[
-        'ilcs-parser @ https://github.com/datamade/ilcs-parser/archive/jfc/init-parser.zip#egg=ilcs-parser-0.0.0',
+        'ilcs-parser @ https://github.com/datamade/ilcs-parser/archive/master.zip#egg=ilcs-parser-0.0.0',
         'parseratorvariable'
     ],
     extras_require={'tests': ['pytest', 'parserator']},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from dedupe.variables.ilcs import ILCSType
+
+
+@pytest.fixture
+def ilcs():
+    return ILCSType({'field': 'foo'})

--- a/tests/test_ilcs.py
+++ b/tests/test_ilcs.py
@@ -1,0 +1,8 @@
+import numpy
+
+
+def test_parse_1(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21', '126 55/21'),
+        numpy.array([1, 0, 1, 2.1666667, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0])
+    )

--- a/tests/test_ilcs.py
+++ b/tests/test_ilcs.py
@@ -1,79 +1,36 @@
 import numpy
-import math
 
 
-def test_chapter_small_delta(ilcs):
+def test_all_distances(ilcs):
     numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21', '126 55/21'),
-        numpy.array([1, 0, 1, math.sqrt(126-125), 0, 0, 0, 0, 1, 1, 1, 0, 0, 0])
+        ilcs.comparator('125 55/21-a (att)', '126 55/21-b (atttt)'),
+        numpy.array([
+            1, 0, 1,
+            ilcs.compareString('126', '125'),
+            ilcs.compareString('55', '55'),
+            ilcs.compareString('21', '21'),
+            ilcs.compareString('a', 'b'),
+            ilcs.compareString('att', 'atttt'),
+            1, 1, 1, 1, 1, 0, 0
+        ])
     )
 
 
-def test_chapter_large_delta(ilcs):
+def test_exact_match(ilcs):
     numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21', '6 55/21'),
-        numpy.array([1, 0, 1, math.sqrt(125-6), 0, 0, 0, 0, 1, 1, 1, 0, 0, 0])
+        ilcs.comparator('125 55/21 (att)', '125 55/21 (att)'),
+        numpy.array([1, 0, 1, 0.5, 0.5, 0.5, 0, 0.5, 1, 1, 1, 0, 1, 0, 1])
     )
 
 
-def test_act_prefix_small_delta(ilcs):
+def test_mismatched_elements(ilcs):
     numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21', '125 56/21'),
-        numpy.array([1, 0, 1, 0, math.sqrt(56-55), 0, 0, 0, 1, 1, 1, 0, 0, 0])
-    )
-
-
-def test_act_prefix_large_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 550/21', '125 5/21'),
-        numpy.array([1, 0, 1, 0, math.sqrt(550-5), 0, 0, 0, 1, 1, 1, 0, 0, 0])
-    )
-
-
-def test_section_small_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21', '125 55/22'),
-        numpy.array([1, 0, 1, 0, 0, math.sqrt(22-21), 0, 0, 1, 1, 1, 0, 0, 0])
-    )
-
-
-def test_section_large_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21', '125 55/210'),
-        numpy.array([1, 0, 1, 0, 0, math.sqrt(210-21), 0, 0, 1, 1, 1, 0, 0, 0])
-    )
-
-
-def test_subsection_small_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21-1', '125 55/21-2'),
-        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(2-1), 0, 1, 1, 1, 1, 0, 0])
-    )
-
-
-def test_subsection_large_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21-1', '125 55/21-100'),
-        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(100-1), 0, 1, 1, 1, 1, 0, 0])
-    )
-
-
-def test_subsection_small_alphabetic_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21-a', '125 55/21-b'),
-        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(1-0), 0, 1, 1, 1, 1, 0, 0])
-    )
-
-
-def test_subsection_large_alphabetic_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21-a', '125 55/21-z'),
-        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(25-0), 0, 1, 1, 1, 1, 0, 0])
-    )
-
-
-def test_attempted_delta(ilcs):
-    numpy.testing.assert_almost_equal(
-        ilcs.comparator('125 55/21 (att)', '125 55/21 (con)'),
-        numpy.array([1, 0, 1, 0, 0, 0, 0, ilcs.compareString('att', 'con'), 1, 1, 1, 0, 1, 0])
+        ilcs.comparator('125 55/21-a (att)', '125 56/21'),
+        numpy.array([
+            1, 0, 1,
+            ilcs.compareString('125', '125'),
+            ilcs.compareString('56', '55'),
+            ilcs.compareString('21', '21'),
+            0, 0, 1, 1, 1, 0, 0, 0, 0
+        ])
     )

--- a/tests/test_ilcs.py
+++ b/tests/test_ilcs.py
@@ -1,8 +1,79 @@
 import numpy
+import math
 
 
-def test_parse_1(ilcs):
+def test_chapter_small_delta(ilcs):
     numpy.testing.assert_almost_equal(
         ilcs.comparator('125 55/21', '126 55/21'),
-        numpy.array([1, 0, 1, 2.1666667, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0])
+        numpy.array([1, 0, 1, math.sqrt(126-125), 0, 0, 0, 0, 1, 1, 1, 0, 0, 0])
+    )
+
+
+def test_chapter_large_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21', '6 55/21'),
+        numpy.array([1, 0, 1, math.sqrt(125-6), 0, 0, 0, 0, 1, 1, 1, 0, 0, 0])
+    )
+
+
+def test_act_prefix_small_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21', '125 56/21'),
+        numpy.array([1, 0, 1, 0, math.sqrt(56-55), 0, 0, 0, 1, 1, 1, 0, 0, 0])
+    )
+
+
+def test_act_prefix_large_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 550/21', '125 5/21'),
+        numpy.array([1, 0, 1, 0, math.sqrt(550-5), 0, 0, 0, 1, 1, 1, 0, 0, 0])
+    )
+
+
+def test_section_small_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21', '125 55/22'),
+        numpy.array([1, 0, 1, 0, 0, math.sqrt(22-21), 0, 0, 1, 1, 1, 0, 0, 0])
+    )
+
+
+def test_section_large_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21', '125 55/210'),
+        numpy.array([1, 0, 1, 0, 0, math.sqrt(210-21), 0, 0, 1, 1, 1, 0, 0, 0])
+    )
+
+
+def test_subsection_small_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21-1', '125 55/21-2'),
+        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(2-1), 0, 1, 1, 1, 1, 0, 0])
+    )
+
+
+def test_subsection_large_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21-1', '125 55/21-100'),
+        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(100-1), 0, 1, 1, 1, 1, 0, 0])
+    )
+
+
+def test_subsection_small_alphabetic_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21-a', '125 55/21-b'),
+        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(1-0), 0, 1, 1, 1, 1, 0, 0])
+    )
+
+
+def test_subsection_large_alphabetic_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21-a', '125 55/21-z'),
+        numpy.array([1, 0, 1, 0, 0, 0, math.sqrt(25-0), 0, 1, 1, 1, 1, 0, 0])
+    )
+
+
+def test_attempted_delta(ilcs):
+    numpy.testing.assert_almost_equal(
+        ilcs.comparator('125 55/21 (att)', '125 55/21 (con)'),
+        numpy.array([1, 0, 1, 0, 0, 0, 0, ilcs.compareString('att', 'con'), 1, 1, 1, 0, 1, 0])
     )


### PR DESCRIPTION
# Overview

Initialize a basic instantiation of `ILCSType` based on the `ParseratorType` provided by https://github.com/dedupeio/parseratorvariable.

## Notes

I'm having some trouble figuring out how to extend the `ParseratorType` API to make more sophisticated comparisons. See my inline comments.

## Testing instructions

- All tests should pass (more tests forthcoming)